### PR TITLE
Added steps to find Rinkeby Test Network Option if its not showing up

### DIFF
--- a/eth-101/lesson-eth-2.md
+++ b/eth-101/lesson-eth-2.md
@@ -24,7 +24,8 @@ To get started you will need a wallet. Your wallet will act as your login to acc
 
 We recommend using [MetaMask](https://metamask.io/). Please store your seed and private keys in a secure place. Create a test account just for this project. We will be using the Rinkeby Test Network, which is a test-network that mimics the the functionality of the real network. This allows us to use Fake Ether as well.
 
-Click on the fox icon in your browser, then click Ethereum Mainnet located at the top center, then in the drop down menu click Rinkeby Test Network.
+Click on the fox icon in your browser, then click Ethereum Mainnet located at the top center, then in the drop down menu click Rinkeby Test Network. 
+(If you dont find Rinkeby Test Network in the dropdown menu, go to settings => advanced => then switch on the 'show test networks' button. Hopefully the Rinkeby Test Network will showup along with other test networks).
 
 Next you will need send your self some fake Ether via what’s known as a faucet. Here are a list of faucets, again double check these as sometimes the faucets are out of fake ether.
 


### PR DESCRIPTION
Hey,
I was going forward with the steps in  2nd lesson of eth101 but  suddenly i found that when i click on networks i found only Etherium Mainnet as an option. (No Rinkeby Test Network was showing)

![image](https://user-images.githubusercontent.com/95861453/149195050-b8ef7680-e3f0-4c34-b9cd-38cde6bef639.png)


Then i struggled a bit and finally found that that is a show test networks button in the advanced section of settings . Which when switched on shows all the test networks available 

![image](https://user-images.githubusercontent.com/95861453/149195329-f29b426a-d159-4949-8983-f5f89d38ff8a.png)


and then finally i was able to connect to Rinkeby Test Network. 
Thus i wanted to update the steps to connect if someone doesn't find a the option like me. I just gave written instructions so that the paragraph looks clean and tidy.

![image](https://user-images.githubusercontent.com/95861453/149195508-5f335e46-9db1-42ec-a1a5-0ea381278bd7.png)



