### PR TITLE
Add semicolon at the end of a statement in the contract

### DIFF
--- a/eth-101/lesson-eth-5.md
+++ b/eth-101/lesson-eth-5.md
@@ -44,7 +44,7 @@ contract Bank {
     }
 
     function withdrawMoney(address payable _to, uint256 _total) public {
-    	require(msg.sender == bankOwner, "You must be the owner to make withdrawals")
+    	require(msg.sender == bankOwner, "You must be the owner to make withdrawals");
         require(
             _total <= customerBalance[msg.sender],
             "You have insuffient funds to withdraw"


### PR DESCRIPTION
**What does this PR do?**
This PR fixes an issue on the Bank contract in Ethereum-101/lesson-eth-5

**Issue to be fixed**
When the Bank contract code is copied and run in the Remix IDE, it refuses to compile and the reason for that is because a Solidity statement in the contract was not delimited by adding a semicolon `;`