### PR TITLE
Remove the limitation that only bank owner or contract creator can withdraw

### DIFF
--- a/eth-101/lesson-eth-5.md
+++ b/eth-101/lesson-eth-5.md
@@ -44,7 +44,6 @@ contract Bank {
     }
 
     function withdrawMoney(address payable _to, uint256 _total) public {
-    	require(msg.sender == bankOwner, "You must be the owner to make withdrawals");
         require(
             _total <= customerBalance[msg.sender],
             "You have insuffient funds to withdraw"


### PR DESCRIPTION
**What does this PR do?**
This PR fixes an issue on the Bank contract in Ethereum-101/lesson-eth-5 that limits the withdrawal of funds to only the Bank owner or contract creator

**Steps to reproduce bug**
- Run the Bank contract on the Remix IDE & deploy the contract with an address, this address becomes the bank owner.
- Now switch the address to another address that is different from the address that created the contract (Bank Owner).
- Deposit funds to the contract with this new address, that will work successfully and deposit the funds to the address
- Still with that address, try withdrawing the funds you just deposited
- You will get a transaction error that: `Only Bank owner can withdraw`

**What Issue was fixed?**
In a banking system, a customer should be able to deposit money into his account and also be able to withdraw money from his account so long as it is not greater than his balance. That is the issue that was fixed in this PR.

How can it be tested?
- Copy the Bank contract and run in the Remix IDE
- Follow the steps to reproduce the bug
- An address should be able to withdraw funds he deposited wether he is the Bank owner or not
