### PR TITLE
corrected error in withDrawMoneyHandler

### DIFF
--- a/eth-101/lesson-eth-8.md
+++ b/eth-101/lesson-eth-8.md
@@ -315,7 +315,7 @@ We're depositing money into our contract. As usual with a transaction function i
         let myAddress = await signer.getAddress()
         console.log("provider signer...", myAddress);
 
-        const txn = await bankContract.withDrawMoney(myAddress, ethers.utils.parseEther(inputValue.withdraw));
+        const txn = await bankContract.withdrawMoney(myAddress, ethers.utils.parseEther(inputValue.withdraw));
         console.log("Withdrawing money...");
         await txn.wait();
         console.log("Money with drew...done", txn.hash);


### PR DESCRIPTION
line const txn = await bankContract.withDrawMoney(myAddress, ethers.utils.parseEther(inputValue.withdraw)); was throwing an error due to the capital "D" in bankContract.withDrawMoney, corrected it to bankContract.withdrawMoney