### PR TITLE
Introduction to course stating incorrect course requirement.

### DIFF
--- a/eth-101/lesson-eth-1.md
+++ b/eth-101/lesson-eth-1.md
@@ -2,7 +2,11 @@
 
 ### How this course works?
 
-In this course you will learn how to build dapps, smart contracts, and deploy them to the Ethereum Blockchain. This course can be completed over a weekend and includes 3 projects that you can add to your portfolio. **In order to qualify for an NFT Certificate you need to submit *one of these 3* projects for review**. Upon review, you will then recieve an NFT Certificate that can be added to your LinkedIn or Resume. 
+In this course you will learn how to build dapps, smart contracts, and deploy them to the Ethereum Blockchain. This course can be completed over a weekend and includes 3 projects that you can add to your portfolio. **In order to qualify for an NFT Certificate you will have two options:**
+1. **Submit Project 1 (your own smart contract and a dapp that interacts with it) & Project 2 (your own meme coin and a dapp that interacts with it).**
+2. **Submit Project 3 (a dapp of your choice).**
+
+Upon review, you will then recieve an NFT Certificate that can be added to your LinkedIn or Resume. 
 
 🔑 Coding experience is required, the key is to push through the lessons to learn the big picture concepts and you will pick up languages like Solidity as you build.
 

--- a/eth-101/lesson-eth-1.md
+++ b/eth-101/lesson-eth-1.md
@@ -8,7 +8,7 @@ In this course you will learn how to build dapps, smart contracts, and deploy th
 
 Upon review, you will then recieve an NFT Certificate that can be added to your LinkedIn or Resume. 
 
-🔑 Coding experience is required, the key is to push through the lessons to learn the big picture concepts and you will pick up languages like Solidity as you build.
+🔑 Coding experience is required. The key is to push through the lessons to learn the big picture concepts and you will pick up languages like Solidity as you build.
 
 ### What's the Ethereum Blockchain? 
 


### PR DESCRIPTION
In lesson-eth-1/1, it says, "In order to qualify for an NFT Certificate you need to submit one of these 3 projects for review," but this does not match with lesson-eth-1/1 where it states, "To qualify for certification you have two options. Your first option is to submit your DAPP Project (Project 1) and your own MemeCoin (project 2) or you can just submit one final project (Project 3)."

I think it is more correct to maintain the "Project 1 & 2 *or* just Project 3" approach so I corrected lesson-eth-1/1 to match that.

Also, made a small change in sentence structure in the second paragraph.