### PR TITLE
Updating Rinkeby to Alchemy Goerli

### DIFF
--- a/nft-101/lesson-nft-1.md
+++ b/nft-101/lesson-nft-1.md
@@ -24,7 +24,7 @@ We're going to use the following tools, technologies, and libraries:
 
 1. Hardhat - To write, compile and deploy our smart contracts.
 2. OpenZepplin - We will be using their ERC721 contract standards and libraries to speed up our development time.
-3. POKT - For our node endpoint to send our contracts up to the Rinkeby testnets.
+3. POKT - For our node endpoint to send our contracts up to the Goerli testnets.
 4. MetaMask - Our wallet of choice to test our dapp.
 5. Ether.js - We will use the ethers library for the front-end of our dapp, in order to interact with our smart contract. Our dapp will be built in React.
 6. [WAGMI](https://wagmi.sh/) (optional) - A set of React Hooks that makes working with ethers more efficient. You can connect a wallet, display ENS and balance information, sign messages, interact with contracts, etc. with a few lines of code.

--- a/nft-101/lesson-nft-4.md
+++ b/nft-101/lesson-nft-4.md
@@ -10,7 +10,7 @@ Before we dive into the code of our smart contract, let's first think about what
 This is as simple as our smart contrat needs to be and infact you can use [OpenZepplin's Wizard](https://docs.openzeppelin.com/contracts/4.x/wizard) to create an ERC 721 contract that does just this. There are NFT Smart Contracts that range in complexity but for our lesson we're going to keep it simple so you can learn the fundementals. 
 
 You can find the tutorial to setup hardhat [here](
-https://app.cadena.dev/ZHjzLozd3mCsAcgMfeHE/lesson/ethereum-101/lesson-eth-6/6) and deploy a smart contract with hardhat [here](https://app.cadena.dev/ZHjzLozd3mCsAcgMfeHE/lesson/ethereum-101/lesson-eth-7/7). Alternatively you can also deploy your smart contract to Rinkeby using Remix. 
+https://app.cadena.dev/ZHjzLozd3mCsAcgMfeHE/lesson/ethereum-101/lesson-eth-6/6) and deploy a smart contract with hardhat [here](https://app.cadena.dev/ZHjzLozd3mCsAcgMfeHE/lesson/ethereum-101/lesson-eth-7/7). Alternatively you can also deploy your smart contract to Goerli using Remix. 
 
 You view the full code for our ERC-721 contract [here](https://gist.github.com/saeedjabbar/ef711176780db78df65ac7ae15d9e3c8) and get the hardhat repo [here](https://github.com/CadenaDev/cadena_nft_smartcontract).
 

--- a/nft-101/lesson-nft-5.md
+++ b/nft-101/lesson-nft-5.md
@@ -36,7 +36,7 @@ const metadataURI = `https://gateway.pinata.cloud/ipfs/INSERT_YOUR_JSON_CID_HERE
 
 ### Viewing your Minted NFTs 
 
-You can see if your NFT's have been minted by viewing them on the Rarible or OpenSea testnets. To do so simply take your smart contract address and paste it in the search bar.
+You can see if your NFT's have been minted by viewing them on the Alchemy Goerli or OpenSea testnets. To do so simply take your smart contract address and paste it in the search bar.
 
 | Testnets | Links                        |
 | -------- | ---------------------------- |


### PR DESCRIPTION
Hey Saaed!

I am John, and I’m an ambassador for Alchemy Alchemy. Love how LearnWeb3DAO Cardena is enhancing developer education in Web3 - kudos.👏👏

Noticed you deployed some of your smart contracts on Rinkeby, which is now deprecated due to the Ethereum Merge. As you probably know, Goerli is now the main testnet.

If helpful, I’m linking Alchemy’s goerli faucet (anyone can get 0.5 Goerli testnet ETH free per day) here - https://goerlifaucet.com/. Also, in case it’s useful to your readers, here’s some good dev docs - https://docs.alchemy.com/.

Let us know if Alchemy can ever be helpful, and keep up the awesome content!

=
John.